### PR TITLE
Update to KDE 5.15 runtime

### DIFF
--- a/io.github.janbar.noson.json
+++ b/io.github.janbar.noson.json
@@ -1,7 +1,7 @@
 {
   "app-id": "io.github.janbar.noson",
   "runtime": "org.kde.Platform",
-  "runtime-version": "5.13",
+  "runtime-version": "5.15",
   "sdk": "org.kde.Sdk",
   "command": "noson-app",
   "rename-icon": "noson",


### PR DESCRIPTION
Creating a speculative PR which will create a build against the still security supported KDE 5.15 runtime for local testing.