### PR TITLE
Update to the 5.15-21.08 runtime

### DIFF
--- a/io.github.janbar.noson.json
+++ b/io.github.janbar.noson.json
@@ -1,7 +1,7 @@
 {
   "app-id": "io.github.janbar.noson",
   "runtime": "org.kde.Platform",
-  "runtime-version": "5.15",
+  "runtime-version": "5.15-21.08",
   "sdk": "org.kde.Sdk",
   "command": "noson-app",
   "rename-icon": "noson",


### PR DESCRIPTION
This updates to a newer, supported freedesktop base with the same KDE/Qt support on top as 5.15.